### PR TITLE
EnumerableExtension/QueryableExtensions bug fixing

### DIFF
--- a/Ci.Sort/EnumerableExtension.cs
+++ b/Ci.Sort/EnumerableExtension.cs
@@ -38,7 +38,7 @@ namespace Ci.Sort
         internal static IEnumerable<T> SortByInternalProperties<T>(IEnumerable<T> query, SortOrder sort,
             PropertyDescriptorCollection properties)
         {
-            if (properties == null || properties.Count != 0)
+            if (properties == null || properties.Count == 0)
             {
                 Debug.WriteLine("Warning - Sort Property wasn't founded!");
                 //todo throw an exception????

--- a/Ci.Sort/QueryableExtensions.cs
+++ b/Ci.Sort/QueryableExtensions.cs
@@ -1,8 +1,10 @@
-﻿using System;
+﻿using Ci.Sort.Enums;
+using Ci.Sort.Models;
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
-using Ci.Sort.Enums;
-using Ci.Sort.Models;
 
 namespace Ci.Sort
 {
@@ -15,18 +17,80 @@ namespace Ci.Sort
 
             if (string.IsNullOrWhiteSpace(sort.Key))
             {
-                Type t = typeof(T);
-                var propInfos = t.GetProperties();
-                sort.Key = propInfos.OrderByDescending(x => x.Name == "Id").First().Name;
+                sort.Key = typeof(T)
+                    .GetProperties()
+                    .OrderByDescending(x => x.Name == "Id")
+                    .First()
+                    .Name;
             }
 
-            var param = Expression.Parameter(typeof(T), "p");
-            var prop = Expression.Property(param, sort.Key);
-            var exp = Expression.Lambda(prop, param);
-            string method = sort.Order == Order.Ascending ? "OrderBy" : "OrderByDescending";
-            Type[] types = new Type[] { query.ElementType, exp.Body.Type };
-            var mce = Expression.Call(typeof(Queryable), method, types, query.Expression, exp);
-            return query.Provider.CreateQuery<T>(mce);
+            var properties = TypeDescriptor.GetProperties(typeof(T));
+
+            var keyProp = properties
+                .Find(sort.Key, true);
+
+            if (keyProp != null)
+            {
+                var param = Expression.Parameter(typeof(T), "p");
+                var prop = Expression.Property(param, keyProp.Name);
+                var exp = Expression.Lambda(prop, param);
+                var method = sort.Order == Order.Ascending ? "OrderBy" : "OrderByDescending";
+                Type[] types = { query.ElementType, exp.Body.Type };
+                var mce = Expression.Call(typeof(Queryable), method, types, query.Expression, exp);
+                return query.Provider.CreateQuery<T>(mce);
+            }
+
+            return SortByInternalProperties(query, sort, properties);
+        }
+
+        internal static IQueryable<T> SortByInternalProperties<T>(IQueryable<T> query, SortOrder sort,
+            PropertyDescriptorCollection properties)
+        {
+            if (properties == null || properties.Count == 0)
+            {
+                Debug.WriteLine("Warning - Sort Property wasn't founded!");
+                //todo throw an exception????
+                return query;
+            }
+
+            PropertyDescriptor keyProp = null;
+            PropertyDescriptor baseProp = null;
+            foreach (PropertyDescriptor property in properties)
+            {
+                baseProp = property;
+                var childProperties = property.GetChildProperties();
+                keyProp = childProperties
+                    .Find(sort.Key, true);
+
+                if (keyProp != null) break;
+            }
+
+            object GetValue(T arg)
+            {
+                var baseValue = baseProp.GetValue(arg);
+                return baseValue != null
+                    ? keyProp.GetValue(baseValue)
+                    : null;//todo throw an exception????
+            }
+
+            if (keyProp != null)
+            {
+                var param = Expression.Parameter(typeof(T), "p");
+                var brop = Expression.Property(param, baseProp.Name);
+                var kprop = Expression.Property(brop, keyProp.Name);
+                var exp = Expression.Lambda(kprop, param);
+                var method = sort.Order == Order.Ascending ? "OrderBy" : "OrderByDescending";
+                Type[] types = { query.ElementType, exp.Body.Type };
+                var mce = Expression.Call(typeof(Queryable), method, types, query.Expression, exp);
+                return query.Provider.CreateQuery<T>(mce);
+            }
+            else
+            {
+                Debug.WriteLine("Warning - Sort Property wasn't founded!");
+                //todo throw an exception????
+            }
+
+            return query;
         }
     }
 }

--- a/Ci.Test/Program.cs
+++ b/Ci.Test/Program.cs
@@ -12,7 +12,6 @@ namespace Ci.Test
     {
         static void Main(string[] args)
         {
-            //working solution
             var sortOrder = new SortOrder
             {
                 Key = nameof(Engine.Name),
@@ -29,8 +28,12 @@ namespace Ci.Test
                 Console.WriteLine($"Engine => {engine.Name}; {engine.EnginePower}");
             }
 
-            //get an Exception
             foreach (var car in DataGenerator.GetCars().Sort(sortOrder))
+            {
+                Console.WriteLine($"Car => Engine => {car.Engine.Name}; {car.Engine.EnginePower}; Seat = > {car.CarSeat.SeatType}");
+            }
+
+            foreach (var car in DataGenerator.GetCars().AsQueryable().Sort(sortOrder))
             {
                 Console.WriteLine($"Car => Engine => {car.Engine.Name}; {car.Engine.EnginePower}; Seat = > {car.CarSeat.SeatType}");
             }


### PR DESCRIPTION
1. :ambulance:  Fixed Critical bug at `EnumerableExtension` connected with Count checking inside the `SortByInternalProperties` method
2. :zap: Provided missed changes for internal sorting at `QueryableExtensions` class

I'm so sorry that forget to provide changes to `QueryableExtensions` class equal to changes in `EnumerableExtension`.
All that mistakes founded only during testing your new NuGet package in a real project.

Also after checking code and re-publishing new version of Ci.Sort library I strongly recommend removing 1.1.0 version of packages caused by a bug in `SortByInternalProperties` method

Thank you